### PR TITLE
NeurIPS talk links swapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TracIn
 [Implementation of Estimating Training Data Influence by Tracing Gradient Descent](https://arxiv.org/pdf/2002.08484.pdf)
-* [NeurIPS 3 mins overview talk](https://videos.neurips.cc/category/34/search/Estimating%20Training%20Data/video/slideslive-38937872?t=0)
-* [NeurIPS 10 mins spotlight talk](https://videos.neurips.cc/category/34/search/Estimating%20Training%20Data/video/slideslive-38936700?t=27)
+* [NeurIPS 3 mins overview talk](https://videos.neurips.cc/category/34/search/Estimating%20Training%20Data/video/slideslive-38936700?t=27)
+* [NeurIPS 10 mins spotlight talk](https://videos.neurips.cc/category/34/search/Estimating%20Training%20Data/video/slideslive-38937872?t=0)
 * [NeurIPS poster](https://github.com/frederick0329/TracIn/blob/master/figures/neurips_poster.pdf)
 
 


### PR DESCRIPTION
It seems the links for the 3 and 10 minute talks were swapped in the README.